### PR TITLE
Stop explicitly installing docker for github CI

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -19,7 +19,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          sudo apt install docker
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements.txt
       - name: Test with molecule


### PR DESCRIPTION
Stop explicitly installing docker for github CI and instead use the version of docker which comes with the `ubuntu-latest` image to prevent installation errors